### PR TITLE
Updated to Core 3.1

### DIFF
--- a/1-Call-MSGraph/daemon-console/daemon-console.csproj
+++ b/1-Call-MSGraph/daemon-console/daemon-console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>daemon_console</RootNamespace>
   </PropertyGroup>
 
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/2-Call-OwnApi/README.md
+++ b/2-Call-OwnApi/README.md
@@ -311,11 +311,11 @@ The relevant code for the Web API is on the `Startup.cs` class. We are using the
     };
     ```
 
-    The protection can also be done on the `Controller` level, using the `Authorize` attribute:
+    The protection can also be done on the `Controller` level, using the `Authorize` attribute and `Policy`. Read more about [policy based authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies?view=aspnetcore-3.1):
 
     ```csharp
     [HttpGet]
-    [Authorize(Roles = "DaemonAppRole")]
+    [Authorize(Policy = "DaemonAppRole")]
     public IActionResult Get()
     {
         ...

--- a/2-Call-OwnApi/TodoList-WebApi/Controllers/TodoListController.cs
+++ b/2-Call-OwnApi/TodoList-WebApi/Controllers/TodoListController.cs
@@ -31,7 +31,7 @@ namespace TodoList_WebApi.Controllers
 
         // GET: api/todolist
         [HttpGet]
-        [Authorize(Roles = "DaemonAppRole")]
+        [Authorize(Policy = "DaemonAppRole")]
         public IActionResult Get()
         {
             return Ok(TodoStore.Values);

--- a/2-Call-OwnApi/TodoList-WebApi/Program.cs
+++ b/2-Call-OwnApi/TodoList-WebApi/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace TodoList_WebApi
 {
@@ -14,11 +7,14 @@ namespace TodoList_WebApi
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/2-Call-OwnApi/TodoList-WebApi/Startup.cs
+++ b/2-Call-OwnApi/TodoList-WebApi/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -43,14 +44,24 @@ namespace TodoList_WebApi
                 options.TokenValidationParameters.RoleClaimType = "roles";
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            // Creating policies that wraps the authorization requirements
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("DaemonAppRole", policy => policy.RequireRole("DaemonAppRole"));
+            });
+
+            services.AddControllers();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
+                // Since IdentityModel version 5.2.1 (or since Microsoft.AspNetCore.Authentication.JwtBearer version 2.2.0),
+                // PII hiding in log files is enabled by default for GDPR concerns.
+                // For debugging/development purposes, one can enable additional detail in exceptions by setting IdentityModelEventSource.ShowPII to true.
+                // Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII = true;
                 app.UseDeveloperExceptionPage();
             }
             else
@@ -60,8 +71,15 @@ namespace TodoList_WebApi
             }
 
             app.UseHttpsRedirection();
+
+            app.UseRouting();
             app.UseAuthentication();
-            app.UseMvc();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/2-Call-OwnApi/TodoList-WebApi/Startup.cs
+++ b/2-Call-OwnApi/TodoList-WebApi/Startup.cs
@@ -59,7 +59,7 @@ namespace TodoList_WebApi
             if (env.IsDevelopment())
             {
                 // Since IdentityModel version 5.2.1 (or since Microsoft.AspNetCore.Authentication.JwtBearer version 2.2.0),
-                // PII hiding in log files is enabled by default for GDPR concerns.
+                // Personal Identifiable Information is not written to the logs by default, to be compliant with GDPR.
                 // For debugging/development purposes, one can enable additional detail in exceptions by setting IdentityModelEventSource.ShowPII to true.
                 // Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII = true;
                 app.UseDeveloperExceptionPage();

--- a/2-Call-OwnApi/TodoList-WebApi/TodoList-WebApi.csproj
+++ b/2-Call-OwnApi/TodoList-WebApi/TodoList-WebApi.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>TodoList_WebApi</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.6.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
+++ b/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>daemon_console</RootNamespace>
   </PropertyGroup>
 

--- a/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.Identity.Web/WebApiStartupHelpers.cs
+++ b/Microsoft.Identity.Web/WebApiStartupHelpers.cs
@@ -54,8 +54,9 @@ namespace Microsoft.Identity.Web
             services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
                     .AddAzureADBearer(options => configuration.Bind("AzureAd", options));
 
+
             // Add session if you are planning to use session based token cache , .AddSessionTokenCaches()
-            services.AddSession();
+            //services.AddSession();
 
             // Change the authentication configuration  to accommodate the Microsoft identity platform endpoint.
             services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>


### PR DESCRIPTION
## Purpose
Fix for https://github.com/Azure-Samples/active-directory-dotnetcore-daemon-v2/issues/47

- Updated to Core 3.1
- Updated to MSAL 4.7.1


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
@jmprieur the builder server is missing Core 3.1 SDK