### PR TITLE
gov cloud updates

### DIFF
--- a/1-Call-MSGraph/README.md
+++ b/1-Call-MSGraph/README.md
@@ -142,12 +142,15 @@ Open the solution in Visual Studio to configure the projects
 
 #### Configure the client project
 
-> Note: if you used the setup scripts, the changes below will have been applied for you
+> Note: if you used the setup scripts, the changes below will have been applied for you, with the exception of the national cloud specific steps.
 
-1. Open the `daemon-console\appsettings.json` file
+1. Open the `daemon-console\appsettings.json` file.
+1. If you are connecting to a national cloud, change the instance to the correct login endpoint. [See this reference for more info.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 1. Find the app key `Tenant` and replace the existing value with your Azure AD tenant name.
 1. Find the app key `ClientId` and replace the existing value with the application ID (clientId) of the `daemon-console` application copied from the Azure portal.
 1. Find the app key `ClientSecret` and replace the existing value with the key you saved during the creation of the `daemon-console` app, in the Azure portal.
+1. If you are connecting to a national cloud, open the 'daemon-console\Program.cs' file.
+1. Change the graph endpoint on lines 88 and 112. [See this reference for more info on which graph endpoint to use.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 
 ### Step 4: Run the sample
 

--- a/1-Call-MSGraph/README.md
+++ b/1-Call-MSGraph/README.md
@@ -145,12 +145,12 @@ Open the solution in Visual Studio to configure the projects
 > Note: if you used the setup scripts, the changes below will have been applied for you, with the exception of the national cloud specific steps.
 
 1. Open the `daemon-console\appsettings.json` file.
-1. If you are connecting to a national cloud, change the instance to the correct login endpoint. [See this reference for more info.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+1. If you are connecting to a national cloud, change the instance to the correct Azure AD endpoint. [See this reference for a list of Azure AD endpoints.](https://docs.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints)
 1. Find the app key `Tenant` and replace the existing value with your Azure AD tenant name.
 1. Find the app key `ClientId` and replace the existing value with the application ID (clientId) of the `daemon-console` application copied from the Azure portal.
 1. Find the app key `ClientSecret` and replace the existing value with the key you saved during the creation of the `daemon-console` app, in the Azure portal.
 1. If you are connecting to a national cloud, open the 'daemon-console\Program.cs' file.
-1. Change the graph endpoint on lines 88 and 112. [See this reference for more info on which graph endpoint to use.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+1. Change the graph endpoint on lines in which there is a "graph.microsoft.com" reference. [See this reference for more info on which graph endpoint to use.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 
 ### Step 4: Run the sample
 

--- a/1-Call-MSGraph/daemon-console/Program.cs
+++ b/1-Call-MSGraph/daemon-console/Program.cs
@@ -84,8 +84,8 @@ namespace daemon_console
 
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by
-            // a tenant administrator. The Graph endpoint may have to be changed for national cloud scenarios, 
-            // refer to the Readme for additional references.
+            // a tenant administrator. The Graph endpoint may have to be changed for national cloud scenarios, refer to
+            // https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
             string[] scopes = new string[] { "https://graph.microsoft.com/.default" };
 
             AuthenticationResult result = null;

--- a/1-Call-MSGraph/daemon-console/Program.cs
+++ b/1-Call-MSGraph/daemon-console/Program.cs
@@ -84,7 +84,8 @@ namespace daemon_console
 
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by
-            // a tenant administrator
+            // a tenant administrator. The Graph endpoint may have to be changed for national cloud scenarios, 
+            // refer to the Readme for additional references.
             string[] scopes = new string[] { "https://graph.microsoft.com/.default" };
 
             AuthenticationResult result = null;

--- a/2-Call-OwnApi/README.md
+++ b/2-Call-OwnApi/README.md
@@ -185,14 +185,17 @@ Open the solution in Visual Studio to configure the projects
 
 #### Configure the client project
 
-> Note: if you used the setup scripts, the changes below will have been applied for you
+> Note: if you used the setup scripts, the changes below will have been applied for you, with the exception of the national cloud specific steps.
 
 1. Open the `Daemon-Console\appsettings.json` file
+1. If you are connecting to a national cloud, change the instance to the correct login endpoint. [See this reference for more info.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 1. Find the app key `Tenant` and replace the existing value with your Azure AD tenant name.
 1. Find the app key `ClientId` and replace the existing value with the application ID (clientId) of the `daemon-console-v2` application copied from the Azure portal.
 1. Find the app key `ClientSecret` and replace the existing value with the key you saved during the creation of the `daemon-console-v2` app, in the Azure portal.
 1. Find the app key `TodoListBaseAddress` and set to `https://localhost:44372`
 1. Find the app key `TodoListScope` and replace the existing value with `api://<web api client id>/.default`. The `<web api client id>` is the application id (clientId) of the web api created above.
+1. If you are connecting to a national cloud, open the 'daemon-console\Program.cs' file.
+1. Change the graph endpoint on lines in which there is a "graph.microsoft.com" reference. [See this reference for more info on which graph endpoint to use.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 
 ### Step 4: Run the sample
 

--- a/2-Call-OwnApi/README.md
+++ b/2-Call-OwnApi/README.md
@@ -188,14 +188,12 @@ Open the solution in Visual Studio to configure the projects
 > Note: if you used the setup scripts, the changes below will have been applied for you, with the exception of the national cloud specific steps.
 
 1. Open the `Daemon-Console\appsettings.json` file
-1. If you are connecting to a national cloud, change the instance to the correct login endpoint. [See this reference for more info.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
+1. If you are connecting to a national cloud, change the instance to the correct Azure AD endpoint. [See this reference for a list of Azure AD endpoints.](https://docs.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints)
 1. Find the app key `Tenant` and replace the existing value with your Azure AD tenant name.
 1. Find the app key `ClientId` and replace the existing value with the application ID (clientId) of the `daemon-console-v2` application copied from the Azure portal.
 1. Find the app key `ClientSecret` and replace the existing value with the key you saved during the creation of the `daemon-console-v2` app, in the Azure portal.
 1. Find the app key `TodoListBaseAddress` and set to `https://localhost:44372`
 1. Find the app key `TodoListScope` and replace the existing value with `api://<web api client id>/.default`. The `<web api client id>` is the application id (clientId) of the web api created above.
-1. If you are connecting to a national cloud, open the 'daemon-console\Program.cs' file.
-1. Change the graph endpoint on lines in which there is a "graph.microsoft.com" reference. [See this reference for more info on which graph endpoint to use.](https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)
 
 ### Step 4: Run the sample
 


### PR DESCRIPTION
I'm not sure if these changes for the login and graph endpoints as tested for the first scenario necessarily apply to the second scenario - I'm assuming they do here. I wasn't sure about the third scenario since it used keyvault and did not have similar steps to the scenario 1 and scenario 2 readmes.