### PR TITLE
Updated all Configure scripts to only use JSON style delimiters for a…

### DIFF
--- a/1-Call-MSGraph/AppCreationScripts-withCert/Configure.ps1
+++ b/1-Call-MSGraph/AppCreationScripts-withCert/Configure.ps1
@@ -74,13 +74,9 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
+
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/1-Call-MSGraph/AppCreationScripts/Configure.ps1
+++ b/1-Call-MSGraph/AppCreationScripts/Configure.ps1
@@ -100,13 +100,8 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/2-Call-OwnApi/AppCreationScripts-withCert/Configure.ps1
+++ b/2-Call-OwnApi/AppCreationScripts-withCert/Configure.ps1
@@ -100,13 +100,8 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/2-Call-OwnApi/AppCreationScripts/Configure.ps1
+++ b/2-Call-OwnApi/AppCreationScripts/Configure.ps1
@@ -100,13 +100,9 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
+
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/3-Using-KeyVault/AppCreationScripts-withCert/Configure.ps1
+++ b/3-Using-KeyVault/AppCreationScripts-withCert/Configure.ps1
@@ -74,13 +74,9 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
+
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/4-Call-OwnApi-Pop/AppCreationScripts-withCert/Configure.ps1
+++ b/4-Call-OwnApi-Pop/AppCreationScripts-withCert/Configure.ps1
@@ -100,13 +100,9 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
+
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter

--- a/4-Call-OwnApi-Pop/AppCreationScripts/Configure.ps1
+++ b/4-Call-OwnApi-Pop/AppCreationScripts/Configure.ps1
@@ -100,13 +100,9 @@ Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requ
 
 Function UpdateLine([string] $line, [string] $value)
 {
-    $index = $line.IndexOf('=')
-    $delimiter = ';'
-    if ($index -eq -1)
-    {
-        $index = $line.IndexOf(':')
-        $delimiter = ','
-    }
+    $index = $line.IndexOf(':')
+    $delimiter = ','
+
     if ($index -ige 0)
     {
         $line = $line.Substring(0, $index+1) + " "+'"'+$value+'"'+$delimiter


### PR DESCRIPTION
…ppsettings.json file creation. Should resolve issues with bad appsettings.json files if a user runs Configure.ps1, Cleanup.ps1 then Configure.ps1 again for all projects.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes bad input being generated for **appsettings.json** files when a user runs **Confirgure.ps1** then **Cleanup.ps1** and finally **Confirgure.ps1** again for all projects. **Confirgure.ps1** currently concatenates new inputs to old inputs after a cleanup when there is an '=' character in the old output (e.g. a base64 string).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
* Run **Configure.ps1** followed by **Cleanup.ps1** and then **Configure.ps1** again in each project's **AppCreationScripts** and **AppCreationScripts-withCert** directory. The **appsettings.json** file should contain valid and proper values for each entry and the project should work as expected.

## What to Check
Verify that the following are valid
* That scripts work as before and that the generated **appsettings.json** will be read as a valid JSON file by each project and the project runs like before.

## Other Information
<!-- Add any other helpful information that may be needed here. -->