### PR TITLE
Added inmemory caching to all samples

### DIFF
--- a/1-Call-MSGraph/daemon-console/Program.cs
+++ b/1-Call-MSGraph/daemon-console/Program.cs
@@ -63,6 +63,8 @@ namespace daemon_console
                     .Build();
             }
 
+            app.AddInMemoryTokenCache();
+
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by
             // a tenant administrator. 

--- a/1-Call-MSGraph/daemon-console/daemon-console.csproj
+++ b/1-Call-MSGraph/daemon-console/daemon-console.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/1-Call-MSGraph/daemon-console/daemon-console.csproj
+++ b/1-Call-MSGraph/daemon-console/daemon-console.csproj
@@ -13,7 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
+++ b/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
@@ -12,7 +12,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.18.0" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
+		<PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 	</ItemGroup>

--- a/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
+++ b/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
@@ -12,9 +12,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
 		<PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+		<PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="1.21.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 	</ItemGroup>
 

--- a/2-Call-OwnApi/daemon-console/Program.cs
+++ b/2-Call-OwnApi/daemon-console/Program.cs
@@ -64,6 +64,8 @@ namespace daemon_console
                     .Build();
             }
 
+            app.AddInMemoryTokenCache();
+
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by
             // a tenant administrator

--- a/3-Using-KeyVault/daemon-console/Program.cs
+++ b/3-Using-KeyVault/daemon-console/Program.cs
@@ -50,6 +50,8 @@ namespace daemon_console
                 .WithCertificate(config.Certificate.Certificate)
                 .WithAuthority(new Uri(config.Authority))
                 .Build();
+            
+            app.AddInMemoryTokenCache();
 
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by

--- a/3-Using-KeyVault/daemon-console/daemon-console.csproj
+++ b/3-Using-KeyVault/daemon-console/daemon-console.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/3-Using-KeyVault/daemon-console/daemon-console.csproj
+++ b/3-Using-KeyVault/daemon-console/daemon-console.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Web.Certificate" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/4-Call-OwnApi-Pop/daemon-console/Daemon-Console.csproj
+++ b/4-Call-OwnApi-Pop/daemon-console/Daemon-Console.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.38.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/4-Call-OwnApi-Pop/daemon-console/Daemon-Console.csproj
+++ b/4-Call-OwnApi-Pop/daemon-console/Daemon-Console.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.28.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.38.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/4-Call-OwnApi-Pop/daemon-console/Program.cs
+++ b/4-Call-OwnApi-Pop/daemon-console/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Web;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -64,6 +65,8 @@ namespace daemon_console
                     .WithAuthority(new Uri(config.Authority))
                     .Build();
             }
+
+            app.AddInMemoryTokenCache();
 
             // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
             // application permissions need to be set statically (in the portal or by PowerShell), and then granted by


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Updated applications to use **AddInMemoryTokenCache** to prevent redundant calls for retrieving access tokens

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

The samples still work the same but now utilize a memory cache for tokens.

See reference documentation [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-net-token-cache-serialization?tabs=aspnetcore).

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  Run all samples and ensure they worked the same as before

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Follow the instructions in each sample.
```

## What to Check
Verify that the following are valid
* Each sample works the same as before
* Samples utilize tokens in the cache if another call is made to retrieve a token.

```
            // Acquire a token (twice)
            var result = await app.AcquireTokenForClient(scopes)
                .ExecuteAsync();
            Console.WriteLine(result.AuthenticationResultMetadata.TokenSource);

            result = await app.AcquireTokenForClient(scopes)
                .ExecuteAsync();
                
           /*
            * If the token has not been acquired from sever this should output:
            * 
            * > IdentityProvider
            * > Cache
            */
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->