### PR TITLE
Update to Id.Web 3.5.0

### DIFF
--- a/1-Call-MSGraph/daemon-console/daemon-console.csproj
+++ b/1-Call-MSGraph/daemon-console/daemon-console.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="3.1.0" />
+	  <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/2-Call-OwnApi/TodoList-WebApi/TodoList-WebApi.csproj
+++ b/2-Call-OwnApi/TodoList-WebApi/TodoList-WebApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+	  <PackageReference Include="Microsoft.Identity.Web" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
+++ b/2-Call-OwnApi/daemon-console/Daemon-Console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 	</ItemGroup>
 

--- a/5-Call-MSGraph-ManagedIdentity/daemon-console/Daemon-Console.csproj
+++ b/5-Call-MSGraph-ManagedIdentity/daemon-console/Daemon-Console.csproj
@@ -12,6 +12,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="3.5.0" />
 	</ItemGroup>
 </Project>

--- a/6-Call-OwnApi-ManagedIdentity/TodoList-WebApi/TodoList-WebApi.csproj
+++ b/6-Call-OwnApi-ManagedIdentity/TodoList-WebApi/TodoList-WebApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+	  <PackageReference Include="Microsoft.Identity.Web" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/6-Call-OwnApi-ManagedIdentity/daemon-console/Daemon-Console.csproj
+++ b/6-Call-OwnApi-ManagedIdentity/daemon-console/Daemon-Console.csproj
@@ -15,8 +15,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 	</ItemGroup>
 

--- a/6-Call-OwnApi-ManagedIdentity/daemon-console/Daemon-Console.csproj
+++ b/6-Call-OwnApi-ManagedIdentity/daemon-console/Daemon-Console.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
Currently the samples are using Id.Web 3.0.0 ... There were bug fixes and new features added in 3.5.0 that we should take advantage of. 

In particular, error messages when Id.Web cannot use any of credentials are clear.